### PR TITLE
use service registration extension methods

### DIFF
--- a/Dfe.Data.SearchPrototype/Web/Dfe.Data.SearchPrototype.Web.csproj
+++ b/Dfe.Data.SearchPrototype/Web/Dfe.Data.SearchPrototype.Web.csproj
@@ -21,8 +21,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dfe.Data.Common.Infrastructure.CognitiveSearch" Version="1.0.1" />
-		<PackageReference Include="Dfe.Data.SearchPrototype" Version="1.0.3" />
-		<PackageReference Include="Dfe.Data.SearchPrototype.Common" Version="1.0.3" />
-		<PackageReference Include="Dfe.Data.SearchPrototype.Infrastructure" Version="1.0.3" />
+		<PackageReference Include="Dfe.Data.SearchPrototype" Version="1.0.4-1" />
+		<PackageReference Include="Dfe.Data.SearchPrototype.Common" Version="1.0.4-1" />
+		<PackageReference Include="Dfe.Data.SearchPrototype.Infrastructure" Version="1.0.4-1" />
 	</ItemGroup>
 </Project>

--- a/Dfe.Data.SearchPrototype/Web/Program.cs
+++ b/Dfe.Data.SearchPrototype/Web/Program.cs
@@ -1,20 +1,11 @@
-using Azure;
-using Azure.Search.Documents;
-using Azure.Search.Documents.Models;
-using Dfe.Data.SearchPrototype.Common.CleanArchitecture.Application.UseCase;
+using Dfe.Data.Common.Infrastructure.CognitiveSearch;
 using Dfe.Data.SearchPrototype.Common.Mappers;
 using Dfe.Data.SearchPrototype.Infrastructure;
-using Dfe.Data.SearchPrototype.Infrastructure.Mappers;
 using Dfe.Data.SearchPrototype.Infrastructure.Options;
-using Dfe.Data.SearchPrototype.Infrastructure.Options.Mappers;
 using Dfe.Data.SearchPrototype.SearchForEstablishments;
 using Dfe.Data.SearchPrototype.Web.Mappers;
 using Dfe.Data.SearchPrototype.Web.Models;
 using GovUk.Frontend.AspNetCore;
-using SearchForEstablishments = Dfe.Data.SearchPrototype.SearchForEstablishments;
-using Infrastructure = Dfe.Data.SearchPrototype.Infrastructure;
-using Dfe.Data.Common.Infrastructure.CognitiveSearch;
-using Dfe.Data.SearchPrototype.SearchForEstablishments.Models;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -25,18 +16,14 @@ builder.Services.AddGovUkFrontend();
 //
 //
 builder.Services.AddDefaultCognitiveSearchServices(builder.Configuration);
-builder.Services.AddScoped(typeof(ISearchServiceAdapter), typeof(CognitiveSearchServiceAdapter<Infrastructure.Establishment>));
-builder.Services.AddScoped<IUseCase<SearchByKeywordRequest, SearchByKeywordResponse>, SearchByKeywordUseCase>();
-builder.Services.AddSingleton(typeof(IMapper<Pageable<SearchResult<Infrastructure.Establishment>>, EstablishmentResults>), typeof(PageableSearchResultsToEstablishmentResultsMapper));
-builder.Services.AddSingleton<IMapper<SearchSettingsOptions, SearchOptions>, SearchOptionsToAzureOptionsMapper>();
+builder.Services.AddCognitiveSearchAdaptorServices();
+builder.Services.AddSearchForEstablishmentServices();
+
 builder.Services.AddSingleton<IMapper<SearchByKeywordResponse, SearchResultsViewModel>, SearchByKeywordResponseToViewModelMapper>();
-builder.Services.AddSingleton<IMapper<Infrastructure.Establishment, Address>, AzureSearchResultToAddressMapper>();
-builder.Services.AddSingleton<IMapper<Infrastructure.Establishment, SearchForEstablishments.Models.Establishment>, AzureSearchResultToEstablishmentMapper>();
 builder.Services.AddOptions<SearchSettingsOptions>("establishments")
     .Configure<IConfiguration>(
         (settings, configuration) =>
             configuration.GetRequiredSection("SearchEstablishment:SearchSettingsOptions").Bind(settings));
-builder.Services.AddScoped<ISearchOptionsFactory, SearchOptionsFactory>();
 //
 //
 // End of IOC container registrations

--- a/Dfe.Data.SearchPrototype/Web/Tests/Dfe.Data.SearchPrototype.Web.Tests.csproj
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Dfe.Data.SearchPrototype.Web.Tests.csproj
@@ -45,10 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Dfe.Data.SearchPrototype.Infrastructure" Version="1.0.3" />
-  </ItemGroup>
-	    
-  <ItemGroup>
     <None Update="appsettings.test.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Dfe.Data.SearchPrototype/WebApi/Dfe.Data.SearchPrototype.WebApi.csproj
+++ b/Dfe.Data.SearchPrototype/WebApi/Dfe.Data.SearchPrototype.WebApi.csproj
@@ -16,9 +16,9 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Dfe.Data.Common.Infrastructure.CognitiveSearch" Version="1.0.1" />
-		<PackageReference Include="Dfe.Data.SearchPrototype" Version="1.0.3" />
-		<PackageReference Include="Dfe.Data.SearchPrototype.Common" Version="1.0.3" />
-		<PackageReference Include="Dfe.Data.SearchPrototype.Infrastructure" Version="1.0.3" />
+		<PackageReference Include="Dfe.Data.SearchPrototype" Version="1.0.4-1" />
+		<PackageReference Include="Dfe.Data.SearchPrototype.Common" Version="1.0.4-1" />
+		<PackageReference Include="Dfe.Data.SearchPrototype.Infrastructure" Version="1.0.4-1" />
 	</ItemGroup>
 
 </Project>

--- a/Dfe.Data.SearchPrototype/WebApi/Program.cs
+++ b/Dfe.Data.SearchPrototype/WebApi/Program.cs
@@ -27,18 +27,13 @@ builder.Services.AddSwaggerGen();
 //
 //
 builder.Services.AddDefaultCognitiveSearchServices(builder.Configuration);
-builder.Services.AddScoped(typeof(ISearchServiceAdapter), typeof(CognitiveSearchServiceAdapter<Infrastructure.Establishment>));
-builder.Services.AddScoped<IUseCase<SearchByKeywordRequest, SearchByKeywordResponse>, SearchByKeywordUseCase>();
-builder.Services.AddSingleton(typeof(IMapper<Pageable<SearchResults<Infrastructure.Establishment>>, EstablishmentResults>), typeof(PageableSearchResultsToEstablishmentResultsMapper));
-builder.Services.AddSingleton<IMapper<SearchSettingsOptions, SearchOptions>, SearchOptionsToAzureOptionsMapper>();
-builder.Services.AddSingleton<IMapper<Infrastructure.Establishment, Address>, AzureSearchResultToAddressMapper>();
-builder.Services.AddSingleton<IMapper<Infrastructure.Establishment, Models.Establishment>, AzureSearchResultToEstablishmentMapper>();
-//builder.Services.AddSingleton<IMapper<EstablishmentResults, SearchByKeywordResponse>, ResultsToResponseMapper>();
+builder.Services.AddCognitiveSearchAdaptorServices();
+builder.Services.AddSearchForEstablishmentServices();
+
 builder.Services.AddOptions<SearchSettingsOptions>("establishments")
     .Configure<IConfiguration>(
         (settings, configuration) =>
             configuration.GetRequiredSection("SearchEstablishment:SearchSettingsOptions").Bind(settings));
-builder.Services.AddScoped<ISearchOptionsFactory, SearchOptionsFactory>();
 //
 //
 // End of IOC container registrations


### PR DESCRIPTION
Use the new extension methods from recent PR in SearchProtoype - so that the knowledge of registering what's needed for each nuget package is self-contained within the nuget