### PR TITLE
Simplify the routing from the initial landing (search) page to the results

### DIFF
--- a/Dfe.Data.SearchPrototype/Web/Controllers/HomeController.cs
+++ b/Dfe.Data.SearchPrototype/Web/Controllers/HomeController.cs
@@ -17,7 +17,7 @@ public class HomeController : Controller
     private readonly ILogger<HomeController> _logger;
     private readonly IUseCase<SearchByKeywordRequest, SearchByKeywordResponse> _searchByKeywordUseCase;
     private readonly ISearchResultsFactory _searchResultsFactory;
-    private readonly IMapper<Dictionary<string, List<string>>, IList<FilterRequest>> _selectedFacetsToFilterRequestsMapper;
+    private readonly IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>> _selectedFacetsToFilterRequestsMapper;
 
     /// <summary>
     /// The following dependencies include the use-case which orchestrates the search functionality,
@@ -42,41 +42,12 @@ public class HomeController : Controller
         ILogger<HomeController> logger,
         IUseCase<SearchByKeywordRequest, SearchByKeywordResponse> searchByKeywordUseCase,
         ISearchResultsFactory searchResultsFactory,
-        IMapper<Dictionary<string, List<string>>, IList<FilterRequest>> selectedFacetsToFilterRequestsMapper)
+        IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>> selectedFacetsToFilterRequestsMapper)
     {
         _logger = logger;
         _searchByKeywordUseCase = searchByKeywordUseCase;
         _searchResultsFactory = searchResultsFactory;
         _selectedFacetsToFilterRequestsMapper = selectedFacetsToFilterRequestsMapper;
-    }
-
-    /// <summary>
-    /// The action method that composes the view model based on the search keyword.
-    /// </summary>
-    /// <param name="searchKeyWord">search keyword</param>
-    /// <returns>
-    /// An IActionResult contract that represents the result of this action method.
-    /// </returns>
-    public async Task<IActionResult> Index(string? searchKeyWord)
-    {
-        if (string.IsNullOrEmpty(searchKeyWord))
-        {
-            return View();
-        }
-
-        ViewBag.SearchQuery = searchKeyWord;
-
-        SearchByKeywordResponse response =
-            await _searchByKeywordUseCase.HandleRequest(
-                new SearchByKeywordRequest(searchKeyword: searchKeyWord));
-
-        SearchResults viewModel =
-            _searchResultsFactory.CreateViewModel(
-                response.EstablishmentResults,
-                new FacetsAndSelectedFacets(
-                    response.EstablishmentFacetResults));
-
-        return View("Index", viewModel);
     }
 
     /// <summary>
@@ -89,29 +60,26 @@ public class HomeController : Controller
     /// <returns>
     /// An IActionResult contract that represents the result of this action method.
     /// </returns>
-    [HttpPost]
-    public async Task<IActionResult> SearchWithFilters(SearchRequest searchRequestViewModel)
+    [HttpGet]
+    public async Task<IActionResult> Index(SearchRequest searchRequestViewModel)
     {
+        if (string.IsNullOrEmpty(searchRequestViewModel.SearchKeyword))
+        {
+            return View();
+        }
         ViewBag.SearchQuery = searchRequestViewModel.SearchKeyword;
 
-        if (searchRequestViewModel.HasSearchKeyWord &&
-            searchRequestViewModel.HasSelectedFacets)
-        {
-            SearchByKeywordResponse response =
-                await _searchByKeywordUseCase.HandleRequest(
-                    new SearchByKeywordRequest(
-                        searchKeyword: searchRequestViewModel.SearchKeyword!,
-                        filterRequests: _selectedFacetsToFilterRequestsMapper.MapFrom(searchRequestViewModel.SelectedFacets!)));
+        SearchByKeywordResponse response =
+            await _searchByKeywordUseCase.HandleRequest(new SearchByKeywordRequest(
+                    searchKeyword: searchRequestViewModel.SearchKeyword!,
+                    filterRequests: _selectedFacetsToFilterRequestsMapper.MapFrom(searchRequestViewModel.SelectedFacets!)));
 
-            SearchResults viewModel =
-                _searchResultsFactory.CreateViewModel(
-                    response.EstablishmentResults,
-                    new FacetsAndSelectedFacets(
-                        response.EstablishmentFacetResults, searchRequestViewModel.SelectedFacets));
+        SearchResults viewModel =
+            _searchResultsFactory.CreateViewModel(
+                response.EstablishmentResults,
+                new FacetsAndSelectedFacets(
+                    response.EstablishmentFacetResults, searchRequestViewModel.SelectedFacets));
 
-            return View("Index", viewModel);
-        }
-
-        return await Index(searchRequestViewModel.SearchKeyword);
+        return View(viewModel);
     }
 }

--- a/Dfe.Data.SearchPrototype/Web/Controllers/HomeController.cs
+++ b/Dfe.Data.SearchPrototype/Web/Controllers/HomeController.cs
@@ -72,7 +72,7 @@ public class HomeController : Controller
         SearchByKeywordResponse response =
             await _searchByKeywordUseCase.HandleRequest(new SearchByKeywordRequest(
                     searchKeyword: searchRequestViewModel.SearchKeyword!,
-                    filterRequests: _selectedFacetsToFilterRequestsMapper.MapFrom(searchRequestViewModel.SelectedFacets!)));
+                    filterRequests: _selectedFacetsToFilterRequestsMapper.MapFrom(searchRequestViewModel.SelectedFacets)));
 
         SearchResults viewModel =
             _searchResultsFactory.CreateViewModel(

--- a/Dfe.Data.SearchPrototype/Web/Mappers/SelectedFacetsToFilterRequestsMapper.cs
+++ b/Dfe.Data.SearchPrototype/Web/Mappers/SelectedFacetsToFilterRequestsMapper.cs
@@ -7,7 +7,7 @@ namespace Dfe.Data.SearchPrototype.Web.Mappers
     /// Facilitates mapping from the received dictionary of selected facets,
     /// into the required list of <see cref="FilterRequest"/> instances.
     /// </summary>
-    public sealed class SelectedFacetsToFilterRequestsMapper : IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>
+    public sealed class SelectedFacetsToFilterRequestsMapper : IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>
     {
         /// <summary>
         /// Provides the functionality to map from user selected facets in the form of a
@@ -19,10 +19,10 @@ namespace Dfe.Data.SearchPrototype.Web.Mappers
         /// <returns>
         /// The configured list of <see cref="FilterRequest"/> instances expected.
         /// </returns>
-        public IList<FilterRequest> MapFrom(Dictionary<string, List<string>> input)
+        public IList<FilterRequest> MapFrom(Dictionary<string, List<string>>? input)
         {
             List<FilterRequest> filterRequests = [];
-
+            if (input == null) { return filterRequests; }
             foreach (KeyValuePair<string, List<string>> filterResult in input)
             {
                 filterRequests.Add(MapFromFilterRequestViewModel(filterResult));

--- a/Dfe.Data.SearchPrototype/Web/Program.cs
+++ b/Dfe.Data.SearchPrototype/Web/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddSearchForEstablishmentServices(builder.Configuration);
 builder.Services.AddScoped<ISearchResultsFactory, SearchResultsFactory>();
 builder.Services.AddSingleton<IMapper<EstablishmentResults?, List<Models.ViewModels.Establishment>?>, EstablishmentResultsToEstablishmentsViewModelMapper>();
 builder.Services.AddSingleton<IMapper<FacetsAndSelectedFacets, List<Facet>?>, FacetsAndSelectedFacetsToFacetsViewModelMapper>();
-builder.Services.AddSingleton<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>, SelectedFacetsToFilterRequestsMapper>();
+builder.Services.AddSingleton<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>?>, SelectedFacetsToFilterRequestsMapper>();
 //
 //
 // End of IOC container registrations

--- a/Dfe.Data.SearchPrototype/Web/Tests/PartialIntegration/HomeControllerTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PartialIntegration/HomeControllerTests.cs
@@ -44,7 +44,7 @@ public class HomeControllerTests
                 new SelectedFacetsToFilterRequestsMapper());
 
         // act
-        IActionResult result = await controller.Index("searchTerm");
+        IActionResult result = await controller.Index(new SearchRequest() { SearchKeyword = "searchTerm" });
 
         // assert
         ViewResult viewResult = Assert.IsType<ViewResult>(result);
@@ -78,7 +78,7 @@ public class HomeControllerTests
                 new SelectedFacetsToFilterRequestsMapper());
 
         // act
-        IActionResult result = await controller.Index("searchTerm");
+        IActionResult result = await controller.Index(new SearchRequest() { SearchKeyword = "searchTerm" });
 
         // assert
         var viewResult = Assert.IsType<ViewResult>(result);
@@ -116,7 +116,7 @@ public class HomeControllerTests
 
         // act
         IActionResult result =
-            await controller.SearchWithFilters(
+            await controller.Index(
                 new SearchRequest()
                 {
                     SearchKeyword = "searchTerm",
@@ -161,7 +161,7 @@ public class HomeControllerTests
 
         // act
         IActionResult result =
-            await controller.SearchWithFilters(
+            await controller.Index(
                 new SearchRequest()
                 {
                     SearchKeyword = "searchTerm",
@@ -210,7 +210,7 @@ public class HomeControllerTests
 
         // act
         IActionResult result =
-            await controller.SearchWithFilters(
+            await controller.Index(
                 new SearchRequest()
                 {
                     SearchKeyword = "searchTerm",

--- a/Dfe.Data.SearchPrototype/Web/Tests/Unit/Controllers/HomeControllerTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Unit/Controllers/HomeControllerTests.cs
@@ -74,34 +74,6 @@ public class HomeControllerTests
     }
 
     [Fact]
-    public async Task Index_NoSearchKeyword_NullViewModel()
-    {
-        // arrange
-        Mock<ILogger<HomeController>> mockLogger = LoggerTestDouble.MockLogger();
-
-        IUseCase<SearchByKeywordRequest, SearchByKeywordResponse> mockUseCase =
-            new SearchByKeywordUseCaseMockBuilder().Create();
-
-        Mock<ISearchResultsFactory> mockSearchResultsFactory = SearchResultsFactoryTestDouble.MockFor(new Web.Models.ViewModels.SearchResults());
-
-        Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> mockRequestMapper =
-            ViewModelSelectedFacetsToFilterRequestMapperTestDouble.MockFor([]);
-
-        //act
-        HomeController controller =
-            new(mockLogger.Object, mockUseCase,
-                mockSearchResultsFactory.Object,
-                mockRequestMapper.Object);
-
-        IActionResult result = await controller.Index(new SearchRequest());
-
-        // assert
-        result.Should().NotBeNull();
-        ViewResult viewResult = Assert.IsType<ViewResult>(result);
-
-    }
-
-    [Fact]
     public async Task SearchWithFilters_NoSearckKeywordOnSearchRequest_NullViewModel()
     {
         // arrange
@@ -121,19 +93,17 @@ public class HomeControllerTests
         SearchRequest searchRequest =
             new()
             {
-                SearchKeyword = null!,
                 SelectedFacets = new Dictionary<string, List<string>>() {
                     { "Facet_1", ["Facet_1_Value"] }
                 }
             };
 
-        //act
         HomeController controller =
             new(mockLogger.Object, mockUseCase,
                 mockSearchResultsFactory.Object,
                 mockRequestMapper.Object);
 
-        // assert/verify
+        // act
         IActionResult result = await controller.Index(searchRequest);
 
         // assert

--- a/Dfe.Data.SearchPrototype/Web/Tests/Unit/Controllers/HomeControllerTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Unit/Controllers/HomeControllerTests.cs
@@ -25,7 +25,7 @@ public class HomeControllerTests
 
         Mock<ISearchResultsFactory> mockSearchResultsFactory = SearchResultsFactoryTestDouble.MockFor(new Web.Models.ViewModels.SearchResults());
 
-        Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> mockRequestMapper =
+        Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> mockRequestMapper =
             ViewModelSelectedFacetsToFilterRequestMapperTestDouble.MockFor([]);
 
         SearchByKeywordResponse response = new(status: SearchResponseStatus.Success)
@@ -42,7 +42,7 @@ public class HomeControllerTests
                 mockSearchResultsFactory.Object,
                 mockRequestMapper.Object);
 
-        await controller.Index("KDM");
+        await controller.Index(new SearchRequest() { SearchKeyword = "KDM" });
 
         Mock.Get(mockUseCase).Verify(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()), Times.Once());
     }
@@ -54,7 +54,7 @@ public class HomeControllerTests
 
         Mock<ISearchResultsFactory> mockSearchResultsFactory = SearchResultsFactoryTestDouble.MockFor(new Web.Models.ViewModels.SearchResults());
 
-        Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> mockRequestMapper =
+        Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> mockRequestMapper =
             ViewModelSelectedFacetsToFilterRequestMapperTestDouble.MockFor([]);
 
         SearchByKeywordResponse response =
@@ -68,7 +68,7 @@ public class HomeControllerTests
                mockSearchResultsFactory.Object,
                 mockRequestMapper.Object);
 
-        await controller.Index("KDM");
+        await controller.Index(new SearchRequest() { SearchKeyword = "KDM" });
 
         mockSearchResultsFactory.Verify(factory => factory.CreateViewModel(It.IsAny<EstablishmentResults?>(), It.IsAny<FacetsAndSelectedFacets>()), Times.Once());
     }
@@ -84,7 +84,7 @@ public class HomeControllerTests
 
         Mock<ISearchResultsFactory> mockSearchResultsFactory = SearchResultsFactoryTestDouble.MockFor(new Web.Models.ViewModels.SearchResults());
 
-        Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> mockRequestMapper =
+        Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> mockRequestMapper =
             ViewModelSelectedFacetsToFilterRequestMapperTestDouble.MockFor([]);
 
         //act
@@ -93,12 +93,12 @@ public class HomeControllerTests
                 mockSearchResultsFactory.Object,
                 mockRequestMapper.Object);
 
-        IActionResult result = await controller.Index(null!);
+        IActionResult result = await controller.Index(new SearchRequest());
 
         // assert
         result.Should().NotBeNull();
         ViewResult viewResult = Assert.IsType<ViewResult>(result);
-        viewResult.Model.Should().BeNull();
+
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class HomeControllerTests
 
         Mock<ISearchResultsFactory> mockSearchResultsFactory = SearchResultsFactoryTestDouble.MockFor(new Web.Models.ViewModels.SearchResults());
 
-        Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> mockRequestMapper =
+        Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> mockRequestMapper =
             ViewModelSelectedFacetsToFilterRequestMapperTestDouble.MockFor([]);
 
         SearchRequest searchRequest =
@@ -134,7 +134,7 @@ public class HomeControllerTests
                 mockRequestMapper.Object);
 
         // assert/verify
-        IActionResult result = await controller.SearchWithFilters(searchRequest);
+        IActionResult result = await controller.Index(searchRequest);
 
         // assert
         ViewResult viewResult = Assert.IsType<ViewResult>(result);

--- a/Dfe.Data.SearchPrototype/Web/Tests/Unit/Mappers/SelectedFacetsToFilterRequestsMapperTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Unit/Mappers/SelectedFacetsToFilterRequestsMapperTests.cs
@@ -1,29 +1,44 @@
 ﻿using Dfe.Data.SearchPrototype.Common.Mappers;
 using Dfe.Data.SearchPrototype.SearchForEstablishments.ByKeyword.Usecase;
 using Dfe.Data.SearchPrototype.Web.Mappers;
-using Dfe.Data.SearchPrototype.Web.Tests.Unit.TestDoubles;
-using Xunit;
 using FluentAssertions;
+using Xunit;
 
-namespace Dfe.Data.SearchPrototype.Web.Tests.Unit.Mappers
+namespace Dfe.Data.SearchPrototype.Web.Tests.Unit.Mappers;
+
+public class SelectedFacetsToFilterRequestsMapperTests
 {
-    public class SelectedFacetsToFilterRequestsMapperTests
+    private readonly SelectedFacetsToFilterRequestsMapper _mapper = new SelectedFacetsToFilterRequestsMapper();
+
+    [Fact]
+    public void Mapper_WithFacetsInput_ReturnsFilterRequests()
     {
-        private readonly IMapper<Dictionary<string, List<string>>, IList<FilterRequest>> _mapper;
-
-        public SelectedFacetsToFilterRequestsMapperTests() => _mapper = new SelectedFacetsToFilterRequestsMapper();
-
-        [Fact]
-        public void Mapper_WithFacetedResultsViewModel_ReturnsFilterRequest()
+        // arrange
+        Dictionary<string, List<string>>? facetSelections = new Dictionary<string, List<string>>
         {
-            // arrange.
-            Dictionary<string, List<string>> viewModel = FacetsSelectedModelTestDouble.Create();
+            { "FacetName1", new List<string> {"FacetValue1a", "FacetValue1b" } },
+            { "FacetName2", new List<string> {"FacetValue2a", "FacetValue2b" } }
+        };
 
-            // act.
-            IList<FilterRequest> response = _mapper.MapFrom(input: viewModel);
+        // act
+        IList<FilterRequest>? response = _mapper.MapFrom(input: facetSelections);
 
-            // assert.
-            response.Should().NotBeEmpty().And.AllBeOfType<FilterRequest>().And.HaveCountGreaterThan(0);
-        }
+        // assert
+        response!.Single(filterRequest => filterRequest.FilterName == "FacetName1")
+            .FilterValues
+            .Should().BeEquivalentTo(facetSelections["FacetName1"]);
+        response!.Single(filterRequest => filterRequest.FilterName == "FacetName2")
+            .FilterValues
+            .Should().BeEquivalentTo(facetSelections["FacetName2"]);
+    }
+
+    [Fact]
+    public void Mapper_NoInput_ReturnsEmptyList()
+    {
+        // act
+        IList<FilterRequest> response = _mapper.MapFrom(null);
+
+        // assert
+        response.Should().BeEmpty();
     }
 }

--- a/Dfe.Data.SearchPrototype/Web/Tests/Unit/TestDoubles/ViewModelSelectedFacetsToFilterRequestMapperTestDouble.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Unit/TestDoubles/ViewModelSelectedFacetsToFilterRequestMapperTestDouble.cs
@@ -6,9 +6,9 @@ namespace Dfe.Data.SearchPrototype.Web.Tests.Unit.TestDoubles
 {
     public static class ViewModelSelectedFacetsToFilterRequestMapperTestDouble
     {
-        public static Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> MockFor(IList<FilterRequest> filterRequests)
+        public static Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> MockFor(IList<FilterRequest> filterRequests)
         {
-            Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> mockMapper = DefaultMock();
+            Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> mockMapper = DefaultMock();
 
             mockMapper.Setup(mapper =>
                 mapper.MapFrom(It.IsAny<Dictionary<string, List<string>>>())).Returns(filterRequests);
@@ -16,6 +16,6 @@ namespace Dfe.Data.SearchPrototype.Web.Tests.Unit.TestDoubles
             return mockMapper;
         }
 
-        public static Mock<IMapper<Dictionary<string, List<string>>, IList<FilterRequest>>> DefaultMock() => new();
+        public static Mock<IMapper<Dictionary<string, List<string>>?, IList<FilterRequest>>> DefaultMock() => new();
     }
 }

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -7,7 +7,7 @@
 }
 
 @* search component *@
-@using (Html.BeginForm("SearchWithFilters", "Home", FormMethod.Post, new { id = "search-establishments" }))
+@using (Html.BeginForm("Index", "Home", FormMethod.Get, new { id = "search-establishments" }))
 {
     <govuk-input input-class="govuk-input govuk-!-width-two-thirds" input-placeholder="Search by keyword" input-value="@searchKeyWord" name="searchKeyWord">
         <govuk-input-label is-page-heading="true" class="govuk-label--l" id="page-heading">Search</govuk-input-label>


### PR DESCRIPTION
More in line with the gov.uk search page - keep the route constant from landing page to results.

Move form submission to a get, which means you can bookmark search results. The routing is now the same, but using query strings to get the results.
