### PR TITLE
Cl/filters presentation layer tests

### DIFF
--- a/Dfe.Data.SearchPrototype/Web/Tests/Dfe.Data.SearchPrototype.Web.Tests.csproj
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Dfe.Data.SearchPrototype.Web.Tests.csproj
@@ -22,6 +22,7 @@
 	
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.1.2" />
+    <PackageReference Include="AngleSharp.Io" Version="1.0.0" />
 	<PackageReference Include="Bogus" Version="35.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
 	<PackageReference Include="Deque.AxeCore.Selenium" Version="4.10.0" />

--- a/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
@@ -20,11 +20,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
 {
     private const string uri = "http://localhost:5000";
     private Mock<IUseCase<SearchByKeywordRequest, SearchByKeywordResponse>> _useCase = new();
+    private readonly HttpClient _client;
 
     private readonly WebApplicationFactory<Program> _factory;
         public SearchPageTests(WebApplicationFactory<Program> factory)
     {
         _factory = factory;
+        _client = CreateHost().CreateClient();
     }
 
     [Fact]
@@ -33,15 +35,14 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         var useCaseResponse = SearchByKeywordResponseTestDouble.CreateWithNoResults();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
-        var client = CreateHost().CreateClient();
 
-        var response = await client.GetAsync(uri);
+        var response = await _client.GetAsync(uri);
         var document = await HtmlHelpers.GetDocumentAsync(response);
 
         var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
         var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
 
-        var formResponse = await client.SendAsync(
+        var formResponse = await _client.SendAsync(
             formElement!,
             formButton!,
             new Dictionary<string, string>
@@ -64,15 +65,14 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         var useCaseResponse = SearchByKeywordResponseTestDouble.CreateWithOneResult();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
-        var client = CreateHost().CreateClient();
 
-        var response = await client.GetAsync(uri);
+        var response = await _client.GetAsync(uri);
         var document = await HtmlHelpers.GetDocumentAsync(response);
 
         var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
         var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
 
-        var formResponse = await client.SendAsync(
+        var formResponse = await _client.SendAsync(
             formElement!,
             formButton!,
             new Dictionary<string, string>
@@ -95,15 +95,14 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
-        var client = CreateHost().CreateClient();
 
-        var response = await client.GetAsync(uri);
+        var response = await _client.GetAsync(uri);
         var document = await HtmlHelpers.GetDocumentAsync(response);
 
         var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
         var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
 
-        var formResponse = await client.SendAsync(
+        var formResponse = await _client.SendAsync(
             formElement!,
             formButton!,
             new Dictionary<string, string>
@@ -126,15 +125,14 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
-        var client = CreateHost().CreateClient();
 
-        var response = await client.GetAsync(uri);
+        var response = await _client.GetAsync(uri);
         var document = await HtmlHelpers.GetDocumentAsync(response);
 
         var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
         var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
 
-        var formResponse = await client.SendAsync(
+        var formResponse = await _client.SendAsync(
             formElement!,
             formButton!,
             new Dictionary<string, string>

--- a/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
@@ -1,5 +1,8 @@
-﻿using AngleSharp.Dom;
+﻿using AngleSharp;
+using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using AngleSharp.Io;
+using AngleSharp.Io.Network;
 using Dfe.Data.SearchPrototype.Common.CleanArchitecture.Application.UseCase;
 using Dfe.Data.SearchPrototype.SearchForEstablishments.ByKeyword.Usecase;
 using Dfe.Data.SearchPrototype.Web.Tests.Shared.Helpers;
@@ -18,15 +21,17 @@ namespace Dfe.Data.SearchPrototype.Web.Tests.PresentationLayerTests;
 
 public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.SearchPrototype.Web.Program>>
 {
-    private const string uri = "http://localhost:5000";
+    private const string uri = "http://localhost";
     private Mock<IUseCase<SearchByKeywordRequest, SearchByKeywordResponse>> _useCase = new();
     private readonly HttpClient _client;
+    private readonly IBrowsingContext _context;
 
     private readonly WebApplicationFactory<Program> _factory;
         public SearchPageTests(WebApplicationFactory<Program> factory)
     {
         _factory = factory;
         _client = CreateHost().CreateClient();
+        _context = CreateBrowsingContext(_client);
     }
 
     [Fact]
@@ -36,21 +41,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var response = await _client.GetAsync(uri);
-        var document = await HtmlHelpers.GetDocumentAsync(response);
+        var document = await _context.OpenAsync(uri);
 
-        var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
-        var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
-
-        var formResponse = await _client.SendAsync(
-            formElement!,
-            formButton!,
-            new Dictionary<string, string>
-            {
-                ["searchKeyWord"] = "anything - I've mocked the response from the use-case regardless of the request"
-            });
-
-        var resultsPage = await HtmlHelpers.GetDocumentAsync(formResponse);
+        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>("#search-establishments-form")!;
+        IDocument resultsPage = await form.SubmitAsync(new
+        {
+            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
+        });
 
         resultsPage.QuerySelector(HomePage.SearchNoResultText.Criteria)!
             .TextContent.Should().Contain("Sorry no results found please amend your search criteria");
@@ -66,21 +63,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var response = await _client.GetAsync(uri);
-        var document = await HtmlHelpers.GetDocumentAsync(response);
+        var document = await _context.OpenAsync(uri);
 
-        var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
-        var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
-
-        var formResponse = await _client.SendAsync(
-            formElement!,
-            formButton!,
-            new Dictionary<string, string>
-            {
-                ["searchKeyWord"] = "anything - I've mocked the response from the use-case regardless of the request"
-            });
-
-        var resultsPage = await HtmlHelpers.GetDocumentAsync(formResponse);
+        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>("#search-establishments-form")!;
+        IDocument resultsPage = await form.SubmitAsync(new
+        {
+            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
+        });
 
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
             .TextContent.Should().Be("1 Result");
@@ -96,21 +85,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var response = await _client.GetAsync(uri);
-        var document = await HtmlHelpers.GetDocumentAsync(response);
+        var document = await _context.OpenAsync(uri);
 
-        var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
-        var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
-
-        var formResponse = await _client.SendAsync(
-            formElement!,
-            formButton!,
-            new Dictionary<string, string>
-            {
-                ["searchKeyWord"] = "anything - I've mocked the response from the use-case regardless of the request"
-            });
-
-        var resultsPage = await HtmlHelpers.GetDocumentAsync(formResponse);
+        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>("#search-establishments-form")!;
+        IDocument resultsPage = await form.SubmitAsync(new
+        {
+            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
+        });
 
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
             .TextContent.Should().Contain("Results");
@@ -126,21 +107,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var response = await _client.GetAsync(uri);
-        var document = await HtmlHelpers.GetDocumentAsync(response);
+        var document = await _context.OpenAsync(uri);
 
-        var formElement = document.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria);
-        var formButton = document.QuerySelector<IHtmlButtonElement>(HomePage.SearchButton.Criteria);
-
-        var formResponse = await _client.SendAsync(
-            formElement!,
-            formButton!,
-            new Dictionary<string, string>
-            {
-                ["searchKeyWord"] = "anything - I've mocked the response from the use-case regardless of the request"
-            });
-
-        var resultsPage = await HtmlHelpers.GetDocumentAsync(formResponse);
+        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>("#search-establishments-form")!;
+        IDocument resultsPage = await form.SubmitAsync(new
+        {
+            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
+        });
 
         var filtersHeading = resultsPage.QuerySelector(HomePage.FiltersHeading.Criteria);
         filtersHeading.Should().NotBeNull();
@@ -161,6 +134,15 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
                 matchedFacet.Should().NotBeNull();
             }
         }
+    }
+
+    private IBrowsingContext CreateBrowsingContext(HttpClient httpClient)
+    {
+        var config = AngleSharp.Configuration.Default
+            .WithRequester(new HttpClientRequester(httpClient))
+            .WithDefaultLoader(new LoaderOptions { IsResourceLoadingEnabled = true });
+
+        return BrowsingContext.New(config);
     }
 
     private WebApplicationFactory<Program> CreateHost()

--- a/Dfe.Data.SearchPrototype/Web/Tests/Shared/Helpers/HtmlHelpers.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Shared/Helpers/HtmlHelpers.cs
@@ -11,7 +11,7 @@ public static class HtmlHelpers
     public static async Task<IHtmlDocument> GetDocumentAsync(this HttpResponseMessage response)
     {
         var content = await response.Content.ReadAsStringAsync();
-        var config = Configuration.Default;
+        var config = Configuration.Default.WithDefaultLoader();
         var document = await
             BrowsingContext.New(config)
                     .OpenAsync(ResponseFactory, CancellationToken.None);

--- a/Dfe.Data.SearchPrototype/Web/Tests/Shared/Pages/HomePage.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Shared/Pages/HomePage.cs
@@ -16,8 +16,8 @@ public sealed class HomePage : BasePage
     public static By SearchSubHeading => By.CssSelector("#searchKeyWord-hint");
     public By SearchHiddenDiv => By.CssSelector("#searchKeyWord + div");
     public static By SearchInput => By.CssSelector("#searchKeyWord");
-    public static By SearchForm => By.CssSelector("#search-establishments");
-    public static By SearchButton => By.CssSelector("#search-establishments button");
+    public static By SearchForm => By.CssSelector("#search-establishments-form");
+    public static By SearchButton => By.CssSelector("#search-establishments-form button");
     public static By SearchResultsNumber => By.CssSelector("#search-results-count");
     public static By SearchResultLinks => By.CssSelector("ul li h4");
     public static By SearchNoResultText => By.CssSelector("#no-results");

--- a/Dfe.Data.SearchPrototype/Web/Tests/Shared/Pages/HomePage.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Shared/Pages/HomePage.cs
@@ -23,6 +23,7 @@ public sealed class HomePage : BasePage
     public static By SearchNoResultText => By.CssSelector("#no-results");
     public static By SearchResultsContainer => By.CssSelector("#results");
     public static By FiltersHeading => By.CssSelector("#filters-heading");
+    public static By FiltersContainer => By.CssSelector("#filters-container");
     public static By SearchResultEstablishmentName(int urn) => By.CssSelector($"#name-{urn}");
     public static By SearchResultEstablishmentUrn(int urn) => By.CssSelector($"#urn-{urn}");
     public static By SearchResultEstablishmentAddress(int urn) => By.CssSelector($"#address-{urn}");

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -36,8 +36,8 @@
                     foreach (var facet in Model.Facets)
                     {
                         <govuk-checkboxes name="selectedFacets[@facet.Name]">
-                            <govuk-checkboxes-fieldset>
-                                <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s" id="FacetName-@facet.Name">
+                            <govuk-checkboxes-fieldset id="FacetName-@facet.Name">
+                                <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s">
                                     @facet.Name
                                 </govuk-checkboxes-fieldset-legend>
 

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -7,8 +7,7 @@
 }
 
 @* search component *@
-@using (Html.BeginForm("Index", "Home", FormMethod.Get, new { id = "search-establishments" }))
-{
+<form asp-action="Index" asp-controller="Home" method="get" id="search-establishments">
     <govuk-input input-class="govuk-input govuk-!-width-two-thirds" input-placeholder="Search by keyword" input-value="@searchKeyWord" name="searchKeyWord">
         <govuk-input-label is-page-heading="true" class="govuk-label--l" id="page-heading">Search</govuk-input-label>
         <govuk-input-hint>Search establishments</govuk-input-hint>
@@ -102,4 +101,4 @@
         @*  end of list component *@
     }
     @* end of display results *@
-}
+</form>

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -12,7 +12,7 @@
         <govuk-input-label is-page-heading="true" class="govuk-label--l" id="page-heading">Search</govuk-input-label>
         <govuk-input-hint>Search establishments</govuk-input-hint>
         <govuk-input-suffix style="padding: 0px">
-            <button style="border: none; cursor:pointer">
+            <button id="search" style="border: none; cursor:pointer">
                 <svg class="gem-c-search__icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
                     <circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>
                     <line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -38,7 +38,7 @@
                     {
                         <govuk-checkboxes name="selectedFacets[@facet.Name]">
                             <govuk-checkboxes-fieldset>
-                                <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s">
+                                <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s" id="FacetName-@facet.Name">
                                     @facet.Name
                                 </govuk-checkboxes-fieldset-legend>
 

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -7,7 +7,7 @@
 }
 
 @* search component *@
-<form asp-action="Index" asp-controller="Home" method="get" id="search-establishments">
+<form asp-action="Index" asp-controller="Home" method="get" id="search-establishments-form">
     <govuk-input input-class="govuk-input govuk-!-width-two-thirds" input-placeholder="Search by keyword" input-value="@searchKeyWord" name="searchKeyWord">
         <govuk-input-label is-page-heading="true" class="govuk-label--l" id="page-heading">Search</govuk-input-label>
         <govuk-input-hint>Search establishments</govuk-input-hint>


### PR DESCRIPTION
A refactor of the existing tests before I add more:
- remove the reliance on the HttpClient Extension methods and use the AngleSharp BrowserContext instead (to submit the form)
- make more use of the methods available from AngleSharp to drill down into the DOM and check that the facets appear in the facets container, and that each facet value (checkbox) appears under the correct facet label. This has meant not using the HomePage model for those bits because it only supplies a string to use with the Anglesharp QuerySelector method