### PR TITLE
Cl/presentation layer tests refactor

### DIFF
--- a/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
@@ -21,7 +21,7 @@ namespace Dfe.Data.SearchPrototype.Web.Tests.PresentationLayerTests;
 
 public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.SearchPrototype.Web.Program>>
 {
-    private const string uri = "http://localhost";
+    private const string homeUri = "http://localhost";
     private Mock<IUseCase<SearchByKeywordRequest, SearchByKeywordResponse>> _useCase = new();
     private readonly HttpClient _client;
     private readonly IBrowsingContext _context;
@@ -35,20 +35,49 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
     }
 
     [Fact]
-    public async Task Search_ByKeyword_WithNoEstablishmentResultsAndNoFacets_ShowsNoResultsText()
+    public async Task Search_SendsKeywordAndSelectedFiltersToUsecase()
     {
+        // arrange
+        var searchTerm = "e.g. School name";
+        SearchByKeywordRequest? capturedUsecaseRequest = default;
+
+        var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
+        _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
+            .Callback<SearchByKeywordRequest>((x) => capturedUsecaseRequest = x)
+            .ReturnsAsync(useCaseResponse);
+
+        // act
+        // navigate to results page with search keyword)
+        var document = await _context.OpenAsync($"{homeUri}?searchKeyword={searchTerm}");
+        // select some filters
+        var checkedBoxes = document.SelectFilters();
+        // submit filtered search
+        IDocument resultsPage = await document.SubmitSearchAsync();
+
+        // assert
+        var usecaseSelectedFacets = capturedUsecaseRequest!
+            .FilterRequests!
+            .SelectMany(request => request
+                .FilterValues
+                .Where(filterValue => checkedBoxes.Select(checkbox => checkbox.Value).Contains(filterValue.ToString()))
+                );
+
+        checkedBoxes.Select(element => element.Value).Should().BeEquivalentTo(usecaseSelectedFacets.Select(facet => facet.ToString()));
+        capturedUsecaseRequest!.SearchKeyword.Should().Be(searchTerm);
+    }
+
+    [Fact]
+    public async Task Search_WithNoEstablishmentResultsAndNoFacets_ShowsNoResultsText()
+    {
+        // arrange
         var useCaseResponse = SearchByKeywordResponseTestDouble.CreateWithNoResults();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var document = await _context.OpenAsync(uri);
+        // act
+        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
 
-        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria)!;
-        IDocument resultsPage = await form.SubmitAsync(new
-        {
-            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
-        });
-
+        // assert
         resultsPage.QuerySelector(HomePage.SearchNoResultText.Criteria)!
             .TextContent.Should().Contain("Sorry no results found please amend your search criteria");
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
@@ -59,18 +88,15 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
     [Fact]
     public async Task Search_ByKeyword_WithSingleEstablishmentResult_Shows1ResultText()
     {
+        // arrange
         var useCaseResponse = SearchByKeywordResponseTestDouble.CreateWithOneResult();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var document = await _context.OpenAsync(uri);
+        // act
+        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
 
-        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria)!;
-        IDocument resultsPage = await form.SubmitAsync(new
-        {
-            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
-        });
-
+        // assert
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
             .TextContent.Should().Be("1 Result");
         resultsPage.QuerySelector(HomePage.SearchResultsContainer.Criteria)!
@@ -81,18 +107,15 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
     [Fact]
     public async Task Search_ByKeyword_WithMultipleEstablishmentResults_ShowsResults()
     {
+        // arrange
         var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var document = await _context.OpenAsync(uri);
+        // act
+        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
 
-        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria)!;
-        IDocument resultsPage = await form.SubmitAsync(new
-        {
-            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
-        });
-
+        // assert
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
             .TextContent.Should().Contain("Results");
         resultsPage.QuerySelector(HomePage.SearchResultsContainer.Criteria)!
@@ -103,18 +126,15 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
     [Fact]
     public async Task Search_ByKeyword_WithFacetedResults_ShowsFacets()
     {
+        // arrange
         var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
         _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
             .ReturnsAsync(useCaseResponse);
 
-        var document = await _context.OpenAsync(uri);
+        // act
+        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
 
-        IHtmlFormElement form = document!.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria)!;
-        IDocument resultsPage = await form.SubmitAsync(new
-        {
-            searchKeyWord = "anything - I've mocked the response from the use-case regardless of the request"
-        });
-
+        // assert
         var filtersHeading = resultsPage.QuerySelector(HomePage.FiltersHeading.Criteria);
         filtersHeading.Should().NotBeNull();
         filtersHeading!.TextContent.Should().Be("Filters");
@@ -125,15 +145,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
         foreach (var expectedFacet in expectedFacets)
         {
             // get the page element and its child nodes for each expected facet - this bit could be done with a page model
-            var matchingFacetPageElement = facetContainer!
-                .GetNodes<IHtmlFieldSetElement>()
-                .Single(element => element.Id != null && element.Id == $"FacetName-{expectedFacet.Name}");
-            var facetLegend = matchingFacetPageElement.GetNodes<IHtmlLegendElement>().Single();
-            var facetInputElements = matchingFacetPageElement.GetNodes<IHtmlInputElement>();
+            var matchingFacetPageElement = resultsPage.GetFacet(expectedFacet.Name);
+            var facetLegend = matchingFacetPageElement.GetLegend();
+            var facetInputElements = matchingFacetPageElement.GetCheckBoxes();
 
-           // assert the facet name is on the page
-           facetLegend.TextContent.Trim().Should().Be(expectedFacet.Name);
-           foreach (var expectedFacetValue in expectedFacet.Results)
+            // assert the facet name is on the page
+            facetLegend.TextContent.Trim().Should().Be(expectedFacet.Name);
+            foreach (var expectedFacetValue in expectedFacet.Results)
             {
                 // assert that each expected facet value appears on the page under the correct facet name
                 var matchedFacet = facetInputElements.Single(inputElement => inputElement!.Value == expectedFacetValue.Value);

--- a/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
@@ -42,7 +42,7 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var landingPage = await _context.OpenAsync($"{homeUri}");
+        var landingPage = await _context.OpenAsync(homeUri);
         landingPage.TypeIntoSearchBox("search terms");
         var resultsPage = await landingPage.SubmitSearchAsync();
 
@@ -63,7 +63,7 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var landingPage = await _context.OpenAsync($"{homeUri}");
+        var landingPage = await _context.OpenAsync(homeUri);
         landingPage.TypeIntoSearchBox("search terms");
         var resultsPage = await landingPage.SubmitSearchAsync();
 
@@ -84,7 +84,7 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var landingPage = await _context.OpenAsync($"{homeUri}");
+        var landingPage = await _context.OpenAsync(homeUri);
         landingPage.TypeIntoSearchBox("search terms");
         var resultsPage = await landingPage.SubmitSearchAsync();
 
@@ -105,7 +105,7 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var landingPage = await _context.OpenAsync($"{homeUri}");
+        var landingPage = await _context.OpenAsync(homeUri);
         landingPage.TypeIntoSearchBox("search terms");
         var resultsPage = await landingPage.SubmitSearchAsync();
 
@@ -142,7 +142,7 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var landingPage = await _context.OpenAsync($"{homeUri}");
+        var landingPage = await _context.OpenAsync(homeUri);
         landingPage.TypeIntoSearchBox("search terms");
         var resultsPage = await landingPage.SubmitSearchAsync();
         var checkedBoxes = resultsPage.SelectFilters();

--- a/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
@@ -34,38 +34,6 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
     }
 
     [Fact]
-    public async Task Search_SendsKeywordAndSelectedFiltersToUsecase()
-    {
-        // arrange
-        var searchTerm = "e.g. School name";
-        SearchByKeywordRequest? capturedUsecaseRequest = default;
-
-        var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
-        _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
-            .Callback<SearchByKeywordRequest>((x) => capturedUsecaseRequest = x)
-            .ReturnsAsync(useCaseResponse);
-
-        // act
-        // navigate to results page with search keyword)
-        var document = await _context.OpenAsync($"{homeUri}?searchKeyword={searchTerm}");
-        // select some filters
-        var checkedBoxes = document.SelectFilters();
-        // submit filtered search
-        IDocument resultsPage = await document.SubmitSearchAsync();
-
-        // assert
-        var usecaseSelectedFacets = capturedUsecaseRequest!
-            .FilterRequests!
-            .SelectMany(request => request
-                .FilterValues
-                .Where(filterValue => checkedBoxes.Select(checkbox => checkbox.Value).Contains(filterValue.ToString()))
-                );
-
-        checkedBoxes.Select(element => element.Value).Should().BeEquivalentTo(usecaseSelectedFacets.Select(facet => facet.ToString()));
-        capturedUsecaseRequest!.SearchKeyword.Should().Be(searchTerm);
-    }
-
-    [Fact]
     public async Task Search_WithNoEstablishmentResultsAndNoFacets_ShowsNoResultsText()
     {
         // arrange
@@ -174,6 +142,38 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
 
         var resultsPageSelectedFacets = resultsPage.GetFacets().SelectMany(facet => facet.GetCheckBoxes().Where(checkBox => checkBox.IsChecked));
         resultsPageSelectedFacets.Select(facet => facet.Value).Should().BeEquivalentTo(checkedBoxes.Select(facet => facet.Value));
+    }
+
+    [Fact]
+    public async Task Search_SendsKeywordAndSelectedFiltersToUsecase()
+    {
+        // arrange
+        var searchTerm = "e.g. School name";
+        SearchByKeywordRequest? capturedUsecaseRequest = default;
+
+        var useCaseResponse = SearchByKeywordResponseTestDouble.Create();
+        _useCase.Setup(useCase => useCase.HandleRequest(It.IsAny<SearchByKeywordRequest>()))
+            .Callback<SearchByKeywordRequest>((x) => capturedUsecaseRequest = x)
+            .ReturnsAsync(useCaseResponse);
+
+        // act
+        // navigate to results page with search keyword)
+        var document = await _context.OpenAsync($"{homeUri}?searchKeyword={searchTerm}");
+        // select some filters
+        var checkedBoxes = document.SelectFilters();
+        // submit filtered search
+        IDocument resultsPage = await document.SubmitSearchAsync();
+
+        // assert
+        var usecaseSelectedFacets = capturedUsecaseRequest!
+            .FilterRequests!
+            .SelectMany(request => request
+                .FilterValues
+                .Where(filterValue => checkedBoxes.Select(checkbox => checkbox.Value).Contains(filterValue.ToString()))
+                );
+
+        checkedBoxes.Select(element => element.Value).Should().BeEquivalentTo(usecaseSelectedFacets.Select(facet => facet.ToString()));
+        capturedUsecaseRequest!.SearchKeyword.Should().Be(searchTerm);
     }
 
     private IBrowsingContext CreateBrowsingContext(HttpClient httpClient)

--- a/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/PresentationLayerTests/SearchPageTests.cs
@@ -42,7 +42,9 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
+        var landingPage = await _context.OpenAsync($"{homeUri}");
+        landingPage.TypeIntoSearchBox("search terms");
+        var resultsPage = await landingPage.SubmitSearchAsync();
 
         // assert
         resultsPage.QuerySelector(HomePage.SearchNoResultText.Criteria)!
@@ -61,7 +63,9 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
+        var landingPage = await _context.OpenAsync($"{homeUri}");
+        landingPage.TypeIntoSearchBox("search terms");
+        var resultsPage = await landingPage.SubmitSearchAsync();
 
         // assert
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
@@ -80,7 +84,9 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
+        var landingPage = await _context.OpenAsync($"{homeUri}");
+        landingPage.TypeIntoSearchBox("search terms");
+        var resultsPage = await landingPage.SubmitSearchAsync();
 
         // assert
         resultsPage.QuerySelector(HomePage.SearchResultsNumber.Criteria)!
@@ -99,7 +105,9 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var resultsPage = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
+        var landingPage = await _context.OpenAsync($"{homeUri}");
+        landingPage.TypeIntoSearchBox("search terms");
+        var resultsPage = await landingPage.SubmitSearchAsync();
 
         // assert
         var filtersHeading = resultsPage.QuerySelector(HomePage.FiltersHeading.Criteria);
@@ -134,13 +142,13 @@ public class SearchPageTests : IClassFixture<WebApplicationFactory<Dfe.Data.Sear
             .ReturnsAsync(useCaseResponse);
 
         // act
-        var document = await _context.OpenAsync($"{homeUri}?searchKeyword=anything");
-        // select some filters
-        var checkedBoxes = document.SelectFilters();
-        // submit filtered search
-        IDocument resultsPage = await document.SubmitSearchAsync();
+        var landingPage = await _context.OpenAsync($"{homeUri}");
+        landingPage.TypeIntoSearchBox("search terms");
+        var resultsPage = await landingPage.SubmitSearchAsync();
+        var checkedBoxes = resultsPage.SelectFilters();
+        IDocument filteredResultsPage = await resultsPage.SubmitSearchAsync();
 
-        var resultsPageSelectedFacets = resultsPage.GetFacets().SelectMany(facet => facet.GetCheckBoxes().Where(checkBox => checkBox.IsChecked));
+        var resultsPageSelectedFacets = filteredResultsPage.GetFacets().SelectMany(facet => facet.GetCheckBoxes().Where(checkBox => checkBox.IsChecked));
         resultsPageSelectedFacets.Select(facet => facet.Value).Should().BeEquivalentTo(checkedBoxes.Select(facet => facet.Value));
     }
 

--- a/Dfe.Data.SearchPrototype/Web/Tests/Shared/Pages/SearchPageHelpers.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Shared/Pages/SearchPageHelpers.cs
@@ -1,0 +1,45 @@
+﻿using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace Dfe.Data.SearchPrototype.Web.Tests.Shared.Pages;
+
+public static class SearchPageHelpers
+{
+    public static IEnumerable<IHtmlFieldSetElement> GetFacets(this IDocument searchPage)
+    {
+        var facetContainer = searchPage.QuerySelector(HomePage.FiltersContainer.Criteria);
+        return facetContainer!
+                .GetNodes<IHtmlFieldSetElement>();
+    }
+    public static IHtmlFieldSetElement GetFacet(this IDocument searchPage, string facetName)
+    {
+        return searchPage.GetFacets().Single(element => element.Id != null && element.Id == $"FacetName-{facetName}");
+    }
+
+    public static IHtmlLegendElement GetLegend(this IHtmlFieldSetElement facetFieldset) =>
+        facetFieldset.GetNodes<IHtmlLegendElement>().Single();
+
+
+    public static IEnumerable<IHtmlInputElement> GetCheckBoxes(this IHtmlFieldSetElement facetFieldset) =>
+        facetFieldset.GetNodes<IHtmlInputElement>();
+
+    public static IEnumerable<IHtmlInputElement> SelectFilters(this IDocument searchPage)
+    {
+        var firstFacetPageElement = searchPage.GetFacets().First();
+        var facetInputElements = firstFacetPageElement.GetCheckBoxes();
+        facetInputElements.First().IsChecked = true;
+        return facetInputElements.Where(inputElement => inputElement.IsChecked);
+    }
+
+    public static void TypeIntoSearchBox(this IDocument searchPage, string content)
+    {
+        var searchBox = searchPage.QuerySelector(HomePage.SearchInput.Criteria) as IHtmlInputElement;
+        searchBox!.Value = content;
+    }
+
+    public static Task<IDocument> SubmitSearchAsync(this IDocument searchPage)
+    {
+        IHtmlFormElement form = searchPage.QuerySelector<IHtmlFormElement>(HomePage.SearchForm.Criteria)!;
+        return form.SubmitAsync();
+    }
+}


### PR DESCRIPTION
Tidied tests by adding some helpers to browse the DOM and perform actions on it (e.g. typing into search text box)
Added test that the filters that are selected show as ticked boxes in the view