### PR TITLE
Use ilocalizer to access display names for facet headers

### DIFF
--- a/Dfe.Data.SearchPrototype/Web/Models/SearchRequest.cs
+++ b/Dfe.Data.SearchPrototype/Web/Models/SearchRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Dfe.Data.SearchPrototype.Web.Models;
+﻿using System.Diagnostics.Eventing.Reader;
+
+namespace Dfe.Data.SearchPrototype.Web.Models;
 
 /// <summary>
 /// The search requests defining model bound view response logic predicated on the status of user input.
@@ -14,15 +16,16 @@ public class SearchRequest
     /// The dictionary of selected facets (grouped by facet name key) provisioned
     /// by binding to user input.
     /// </summary>
-    public Dictionary<string, List<string>>? SelectedFacets { get; set; }
+    public Dictionary<string, List<string>>? SelectedFacets
+    {
+        get
+        {
+            if (ClearFilters) _selectedFacets = null;
+            return _selectedFacets;
+        }
+        set { _selectedFacets = value; }
+    }
 
-    /// <summary>
-    /// Conditionally checks if any facet values have been selected.
-    /// </summary>
-    public bool HasSelectedFacets => SelectedFacets?.Count > 0;
-
-    /// <summary>
-    /// Conditionally checks if a search keyword has been submitted.
-    /// </summary>
-    public bool HasSearchKeyWord => !string.IsNullOrWhiteSpace(SearchKeyword);
+    private Dictionary<string, List<string>>? _selectedFacets;
+    public bool ClearFilters { get; set; }
 }

--- a/Dfe.Data.SearchPrototype/Web/Models/SearchRequest.cs
+++ b/Dfe.Data.SearchPrototype/Web/Models/SearchRequest.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.Eventing.Reader;
-
-namespace Dfe.Data.SearchPrototype.Web.Models;
+﻿namespace Dfe.Data.SearchPrototype.Web.Models;
 
 /// <summary>
 /// The search requests defining model bound view response logic predicated on the status of user input.
@@ -16,16 +14,15 @@ public class SearchRequest
     /// The dictionary of selected facets (grouped by facet name key) provisioned
     /// by binding to user input.
     /// </summary>
-    public Dictionary<string, List<string>>? SelectedFacets
-    {
-        get
-        {
-            if (ClearFilters) _selectedFacets = null;
-            return _selectedFacets;
-        }
-        set { _selectedFacets = value; }
-    }
+    public Dictionary<string, List<string>>? SelectedFacets { get; set; }
 
-    private Dictionary<string, List<string>>? _selectedFacets;
-    public bool ClearFilters { get; set; }
+    /// <summary>
+    /// Conditionally checks if any facet values have been selected.
+    /// </summary>
+    public bool HasSelectedFacets => SelectedFacets?.Count > 0;
+
+    /// <summary>
+    /// Conditionally checks if a search keyword has been submitted.
+    /// </summary>
+    public bool HasSearchKeyWord => !string.IsNullOrWhiteSpace(SearchKeyword);
 }

--- a/Dfe.Data.SearchPrototype/Web/Program.cs
+++ b/Dfe.Data.SearchPrototype/Web/Program.cs
@@ -13,7 +13,8 @@ using Models = Dfe.Data.SearchPrototype.Web.Models;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddControllersWithViews();
+builder.Services.AddControllersWithViews()
+    .AddViewLocalization(options => { options.ResourcesPath = "Resources"; });
 builder.Services.AddGovUkFrontend();
 
 // Start of IOC container registrations

--- a/Dfe.Data.SearchPrototype/Web/Resources/Views.Home.Index.resx
+++ b/Dfe.Data.SearchPrototype/Web/Resources/Views.Home.Index.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ESTABLISHMENTSTATUSNAME" xml:space="preserve">
+    <value>Establishment status</value>
+  </data>
+  <data name="PHASEOFEDUCATION" xml:space="preserve">
+    <value>Phase of education</value>
+  </data>
+</root>

--- a/Dfe.Data.SearchPrototype/Web/Tests/Unit/Models/EstablishmentViewModelTests.cs
+++ b/Dfe.Data.SearchPrototype/Web/Tests/Unit/Models/EstablishmentViewModelTests.cs
@@ -37,7 +37,7 @@ public class EstablishmentViewModelTests
     [InlineData("", null, null, null, null, "")]
     [InlineData(null, null, null, null, null, "")]
     public void AddressAsString_NullAddressValues_ReturnsFormattedString(
-         string street, string locality, string address3, string town, string postcode, string expectedString)
+         string? street, string? locality, string? address3, string? town, string? postcode, string? expectedString)
     {
         // arrange
         Establishment establishmentViewModel = new()

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@using Dfe.Data.SearchPrototype.Web.Models.ViewModels
+@using Microsoft.AspNetCore.Mvc.Localization
 @model SearchResults
-
+@inject IViewLocalizer Localizer;
 @{
     ViewData["Title"] = "Search Results";
     var searchKeyWord = ViewBag.SearchQuery as string;
@@ -38,7 +39,7 @@
                         <govuk-checkboxes name="selectedFacets[@facet.Name]">
                             <govuk-checkboxes-fieldset id="FacetName-@facet.Name">
                                 <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s">
-                                    @facet.Name
+                                    @Localizer[facet.Name]
                                 </govuk-checkboxes-fieldset-legend>
 
                                 @foreach (var facetValue in facet.Values)

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -32,9 +32,6 @@
                 <button type="submit" class="govuk-button" data-module="govuk-button">
                     Apply filters
                 </button>
-                <button type="submit" name="ClearFilters" value="true" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                    Clear filters
-                </button>
                 @if (Model.Facets is not null && Model.Facets.Any())
                 {
                     foreach (var facet in Model.Facets)

--- a/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
+++ b/Dfe.Data.SearchPrototype/Web/Views/Home/Index.cshtml
@@ -32,6 +32,9 @@
                 <button type="submit" class="govuk-button" data-module="govuk-button">
                     Apply filters
                 </button>
+                <button type="submit" name="ClearFilters" value="true" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                    Clear filters
+                </button>
                 @if (Model.Facets is not null && Model.Facets.Any())
                 {
                     foreach (var facet in Model.Facets)


### PR DESCRIPTION
Use display-friendly equivalents for data facet field names and values.
Uses the .Net support for localisation to load nice display names for facets